### PR TITLE
World map: maximal overview on start + wheel scroll zoom

### DIFF
--- a/openfreemap-worldmap/src/App.tsx
+++ b/openfreemap-worldmap/src/App.tsx
@@ -31,14 +31,16 @@ export default function App() {
         const map = new window.maplibregl.Map({
           container: mapContainerRef.current!,
           style: OFM_STYLE_URL,
-          center: [8, 50],
-          zoom: 4.2,
+          center: [0, 20],
+          zoom: 0,
+          minZoom: 0,
           maxZoom: 20,
           renderWorldCopies: false,
           attributionControl: false,
-          cooperativeGestures: true,
+          cooperativeGestures: false,
         });
         mapRef.current = map;
+        try { map.scrollZoom.enable(); } catch {}
 
         map.addControl(new window.maplibregl.NavigationControl({ visualizePitch: true }), "top-left");
         map.addControl(new window.maplibregl.ScaleControl({ maxWidth: 140, unit: "metric" }), "bottom-left");


### PR DESCRIPTION
## Summary
- Set default map zoom to 0 for maximal world overview on first load
- Adjust initial center to [0, 20] to frame the globe more neutrally
- Enable scroll wheel zoom without requiring Ctrl by disabling cooperativeGestures
- Explicitly enable scrollZoom for clarity

## Rationale (Why)
This improves the initial user experience by showing the largest possible overview of the world map and making zooming in/out intuitive via the mouse wheel (without needing Ctrl/Cmd).

## Changes (What)
- openfreemap-worldmap/src/App.tsx
  - `zoom: 0` and `minZoom: 0`
  - `center: [0, 20]`
  - `cooperativeGestures: false`
  - `map.scrollZoom.enable()` after map creation

## Impact
- UX improvement only; no breaking API changes
- Navigation buttons and other interactions remain unchanged

## Notes
If you prefer a different initial center, e.g., `[0, 0]`, I can adjust it. The style continues to use `renderWorldCopies: false` as before.

₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/af7193b1-1b9b-42fa-b2be-605d968004f8/task/8ee8dfdb-65a5-47b8-b1a9-9208530ddf31))